### PR TITLE
Using $(ICED) instead of global iced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,6 @@ setup:
 	npm install -d
 
 test:
-	(cd test && iced run.iced)
+	(cd test && ../$(ICED) run.iced)
 
 .PHONY: test setup


### PR DESCRIPTION
Makefile expected iced to be installed globally; this uses the previously instantiated ICED var.
