### PR TITLE
Make passphrase prompts more consistent.

### DIFF
--- a/lib/command/join.js
+++ b/lib/command/join.js
@@ -101,11 +101,11 @@
           checker: checkers.username
         },
         passphrase: {
-          prompt: "Your passphrase",
+          prompt: "Your login passphrase",
           passphrase: true,
           checker: checkers.passphrase,
           confirm: {
-            prompt: "confirm passphrase"
+            prompt: "Repeat to confirm"
           }
         }
       };

--- a/test/lib/user.iced
+++ b/test/lib/user.iced
@@ -171,9 +171,9 @@ exports.User = class User
         { sendline : "202020202020202020202020" }
         { expect : "Your desired username: " }
         { sendline : @username }
-        { expect : "Your passphrase: " }
+        { expect : "Your login passphrase: " }
         { sendline : @password }
-        { expect : "confirm passphrase: " }
+        { expect : "Repeat to confirm: " }
         { sendline : @password },
       ], defer err
     unless err?


### PR DESCRIPTION
Currently, during the signup process in the command line, the wording used to refer to the passphrases is somewhat inconsistent if the user goes on to generate their key using key base.

``` sh
$ keybase signup
Your email: abc@def.com
Invitation code (leave blank if you don't have one): 1234abc...
Your passphrase: *************************
confirm passphrase: *************************

...

$ keybase gen --push
Your key passphrase (can be the same as your login passphrase): *************************
Repeat to confirm: *************************
```

You are asked to provide "Your passphrase", which is later referred to as "your login passphrase". I think the latter term is clearer.

I also think "Repeat to confirm" should be used as the confirmation for the login passphrase as well.

My proposed changes would look like this:

``` sh
$ keybase signup
Your email: abc@def.com
Invitation code (leave blank if you don't have one): 1234abc...
Your login passphrase: *************************
Repeat to confirm: *************************

...

$ keybase gen --push
Your key passphrase (can be the same as your login passphrase): *************************
Repeat to confirm: *************************
```

Other thoughts: Should the prompt make it clearer these are being chosen for the first time? It may be that being prompted with "Your passphrase:" or the proposed "Your login passphrase:" looks like the user already has one and should provide it.
