### PR TITLE
Fix typo in "passphrase"

### DIFF
--- a/lib/command/base.js
+++ b/lib/command/base.js
@@ -71,7 +71,7 @@
 
     Base.OPTS = {
       p: {
-        alias: 'passhrase',
+        alias: 'passphrase',
         help: 'passphrase used to log into keybase'
       },
       c: {

--- a/src/command/base.iced
+++ b/src/command/base.iced
@@ -45,7 +45,7 @@ exports.Base = class Base
 
   @OPTS :
     p :
-      alias : 'passhrase'
+      alias : 'passphrase'
       help : 'passphrase used to log into keybase'
     c :
       alias : 'config'
@@ -163,4 +163,3 @@ exports.Base = class Base
     cb err
 
 #=========================================================================
-


### PR DESCRIPTION
Turned out "passhrase" in a couple places.
