### PR TITLE
fix writing proofs to output files

### DIFF
--- a/lib/command/prove.js
+++ b/lib/command/prove.js
@@ -339,7 +339,7 @@
                 filename: "/home/max/src/keybase/node-client/src/command/prove.iced",
                 funcname: "Command.handle_post"
               });
-              fs.writeFile(f, _this.gen.get_proof_text(), esc(__iced_deferrals.defer({
+              fs.writeFile(f, _this.gen.show_proof_text(), esc(__iced_deferrals.defer({
                 lineno: 123
               })));
               __iced_deferrals._fulfill();

--- a/src/command/prove.iced
+++ b/src/command/prove.iced
@@ -121,7 +121,7 @@ exports.Command = class Command extends ProofBase
     log.console.log ""
     if (f = @argv.output)?
       log.info "Writing proof to file '#{f}'..."
-      await fs.writeFile f, @gen.get_proof_text(), esc defer()
+      await fs.writeFile f, @gen.show_proof_text(), esc defer()
       log.info "Wrote proof to '#{f}'"
     else
       log.console.log @gen.show_proof_text()


### PR DESCRIPTION
Fixes e.g. `keybase prove github -o github_proof.txt`, which was giving me a traceback like the following:

`TypeError: Object #<GithubProofGen> has no method 'get_proof_text'
    at prompt (/usr/local/lib/node_modules/keybase/lib/command/prove.js:342:41)
    at prompt (/usr/local/lib/node_modules/keybase/lib/command/prove.js:346:15)
    at Command.exports.Command.Command.handle_post (/usr/local/lib/node_modules/keybase/lib/command/prove.js:353:15)
    at /usr/local/lib/node_modules/keybase/lib/command/prove.js:589:39
    at /usr/local/lib/node_modules/keybase/lib/command/prove.js:593:33
    at Deferrals.exports.Deferrals.Deferrals._call (/usr/local/lib/node_modules/keybase/node_modules/iced-runtime/lib/runtime.js:86:16)
    at /usr/local/lib/node_modules/keybase/node_modules/iced-runtime/lib/runtime.js:98:26
    at exports.trampoline.trampoline (/usr/local/lib/node_modules/keybase/node_modules/iced-runtime/lib/runtime.js:64:14)
    at Deferrals.exports.Deferrals.Deferrals._fulfill (/usr/local/lib/node_modules/keybase/node_modules/iced-runtime/lib/runtime.js:96:16)
    at ret (/usr/local/lib/node_modules/keybase/node_modules/iced-runtime/lib/runtime.js:29:18)`
