### PR TITLE
allow encrypt/decrypt to accept & output base64.

### DIFF
--- a/src/command/decrypt_and_verify.iced
+++ b/src/command/decrypt_and_verify.iced
@@ -42,6 +42,8 @@ exports.Command = class Command extends Base
     m:
       alias : "message"
       help : "provide the message on the command line"
+    "message6":
+      help : "provide the message on the command line, as base64"
   }
 
   #----------

--- a/src/command/encrypt.iced
+++ b/src/command/encrypt.iced
@@ -24,10 +24,16 @@ exports.Command = class Command extends Base
     m:
       alias : "message"
       help : "provide the message on the command line"
+    "message6":
+      help : "provide the message on the command line, as base64"
     b :
       alias : 'binary'
       action: "storeTrue"
       help : "output in binary (rather than ASCII/armored)"
+    '6' :
+      alias : "base64"
+      action : "storeTrue"
+      help : "output result as base64-encoded binary data (rather than ASCII/armored)"
     o :
       alias : 'output'
       help : 'the output file to write the encryption to'
@@ -65,13 +71,17 @@ exports.Command = class Command extends Base
     args.push "-a"  unless @argv.binary
     if @argv.message
       gargs.stdin = new BufferInStream @argv.message
+    else if @argv.message6
+      gargs.stdin = new BufferInStream(new Buffer(@argv.message6, "base64"))
     else if @argv.file?
       args.push @argv.file
     else
       gargs.stdin = process.stdin
     await master_ring().gpg gargs, defer err, out
     unless @argv.output?
-      if @argv.binary
+      if @argv.base64
+        await process.stdout.write out.toString("base64"), defer()
+      else if @argv.binary
         await process.stdout.write out, defer()
       else
         log.console.log out.toString('utf8')

--- a/src/dve.iced
+++ b/src/dve.iced
@@ -181,6 +181,8 @@ exports.DecryptAndVerifyEngine = class DecryptAndVerifyEngine
     gargs.stderr = new BufferOutStream()
     if @argv.message
       gargs.stdin = new BufferInStream @argv.message
+    if @argv.message6
+      gargs.stdin = new BufferInStream(new Buffer(@argv.message6, "base64"))
     else if not @get_files(args)
       gargs.stdin = process.stdin
       @batch = true


### PR DESCRIPTION
This will allow binary messages to be encrypted and decrypted using the command-line. (I'd like to use this to encrypt the key for archives in 4Q: https://github.com/robey/4q )
