### PR TITLE
keygen: "send private key to keybase" default -> false

### DIFF
--- a/src/command/keygen.iced
+++ b/src/command/keygen.iced
@@ -49,7 +49,7 @@ exports.Command = class Command extends pg.Command
     err = ret = null
     if @argv.secret then ret = true
     else
-      await prompt_yn { prompt : "Push your encrypted private key to the server?", defval : true }, defer err, ret
+      await prompt_yn { prompt : "Push your encrypted private key to the server?", defval : false }, defer err, ret
     cb err, ret
 
   #----------


### PR DESCRIPTION
Private keys (even when encrypted) are sensitive pieces of information.
To promote better security practices, the default probably shouldn't be
to trust *anyone* (even keybase) with them.