### PR TITLE
added keybase-installer as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "iced-spawn": ">=1.0.0",
     "iced-utils": "0.1.20",
     "kbpgp": ">=1.0.2",
+    "keybase-installer": "1.0.1",
     "keybase-path": "0.0.15",
     "keybase-proofs": "^2.0.13",
     "libkeybase": "^0.0.6",


### PR DESCRIPTION
`keybase update` needs keybase-installer presence, so it should be in the dependency list.
In the normal use case keybase gets installed via keybase-installer, but since it gets now distributed via brew and a ppa as well its presence is no longer implicit. (see https://github.com/keybase/keybase-issues/issues/1477)