### PR TITLE
Add support for multiple recipients.

### DIFF
--- a/lib/command/encrypt.js
+++ b/lib/command/encrypt.js
@@ -78,17 +78,21 @@
     };
 
     Command.prototype.do_encrypt = function(cb) {
-      var args, err, gargs, key, o, out, sign_key, ___iced_passed_deferral, __iced_deferrals, __iced_k, _i, _len, _ref;
+      var args, err, gargs, key, o, out, sign_key, target, ___iced_passed_deferral, __iced_deferrals, __iced_k, _i, _j, _len, _len1, _ref, _ref1;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       args = ["--encrypt", "--trust-mode", "always"];
-      _ref = this.them.gpg_keys;
+      _ref = this.targets;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
-        key = _ref[_i];
-        args = args.concat("-r", key.fingerprint().toString('hex'));
+        target = _ref[_i];
+        _ref1 = target.user.gpg_keys;
+        for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
+          key = _ref1[_j];
+          args = args.concat("-r", key.fingerprint().toString('hex'));
+        }
       }
       if (this.argv.sign) {
-        sign_key = this.is_self ? this.them : this.tssc.me;
+        sign_key = this.targets[0].is_self ? this.targets[0].user : this.targets[0].tssc.me;
         args.push("--sign", "-u", sign_key.fingerprint(true));
       }
       gargs = {
@@ -112,7 +116,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/home/jacko/node-client/src/command/encrypt.iced",
+            filename: "/home/miles/code/vendor/keybase-node-client/src/command/encrypt.iced",
             funcname: "Command.do_encrypt"
           });
           master_ring().gpg(gargs, __iced_deferrals.defer({
@@ -122,7 +126,7 @@
                 return out = arguments[1];
               };
             })(),
-            lineno: 70
+            lineno: 71
           }));
           __iced_deferrals._fulfill();
         });
@@ -135,11 +139,11 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/home/jacko/node-client/src/command/encrypt.iced",
+                      filename: "/home/miles/code/vendor/keybase-node-client/src/command/encrypt.iced",
                       funcname: "Command.do_encrypt"
                     });
                     process.stdout.write(out, __iced_deferrals.defer({
-                      lineno: 73
+                      lineno: 74
                     }));
                     __iced_deferrals._fulfill();
                   })(__iced_k);
@@ -158,7 +162,7 @@
     };
 
     Command.prototype.run = function(cb) {
-      var assertions, batch, esc, them_un, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var assertions, batch, esc, i, target, target_unames, them_un, uname, user, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       esc = make_esc(cb, "Command::run");
@@ -167,87 +171,123 @@
         cb(new Error("You can't sign messages when you aren't logged in."));
         return;
       }
+      target_unames = this.argv.them[0].split(",");
+      this.targets = [];
       (function(_this) {
         return (function(__iced_k) {
-          __iced_deferrals = new iced.Deferrals(__iced_k, {
-            parent: ___iced_passed_deferral,
-            filename: "/home/jacko/node-client/src/command/encrypt.iced",
-            funcname: "Command.run"
-          });
-          User.resolve_user_name({
-            username: _this.argv.them[0]
-          }, esc(__iced_deferrals.defer({
-            assign_fn: (function() {
-              return function() {
-                them_un = arguments[0];
-                return assertions = arguments[1];
+          var _i, _len, _ref, _results, _while;
+          _ref = target_unames;
+          _len = _ref.length;
+          i = 0;
+          _results = [];
+          _while = function(__iced_k) {
+            var _break, _continue, _next;
+            _break = function() {
+              return __iced_k(_results);
+            };
+            _continue = function() {
+              return iced.trampoline(function() {
+                ++i;
+                return _while(__iced_k);
+              });
+            };
+            _next = function(__iced_next_arg) {
+              _results.push(__iced_next_arg);
+              return _continue();
+            };
+            if (!(i < _len)) {
+              return _break();
+            } else {
+              uname = _ref[i];
+              target = _this.targets[i] = {
+                uname: uname
               };
-            })(),
-            lineno: 91
-          })));
-          __iced_deferrals._fulfill();
+              (function(__iced_k) {
+                __iced_deferrals = new iced.Deferrals(__iced_k, {
+                  parent: ___iced_passed_deferral,
+                  filename: "/home/miles/code/vendor/keybase-node-client/src/command/encrypt.iced",
+                  funcname: "Command.run"
+                });
+                User.resolve_user_name({
+                  username: uname
+                }, esc(__iced_deferrals.defer({
+                  assign_fn: (function() {
+                    return function() {
+                      them_un = arguments[0];
+                      return assertions = arguments[1];
+                    };
+                  })(),
+                  lineno: 96
+                })));
+                __iced_deferrals._fulfill();
+              })(function() {
+                (function(__iced_k) {
+                  if (env().is_me(them_un)) {
+                    target.is_self = true;
+                    (function(__iced_k) {
+                      __iced_deferrals = new iced.Deferrals(__iced_k, {
+                        parent: ___iced_passed_deferral,
+                        filename: "/home/miles/code/vendor/keybase-node-client/src/command/encrypt.iced",
+                        funcname: "Command.run"
+                      });
+                      User.load_me({
+                        secret: true
+                      }, esc(__iced_deferrals.defer({
+                        assign_fn: (function() {
+                          return function() {
+                            return user = arguments[0];
+                          };
+                        })(),
+                        lineno: 100
+                      })));
+                      __iced_deferrals._fulfill();
+                    })(function() {
+                      return __iced_k(target.user = user);
+                    });
+                  } else {
+                    target.is_self = false;
+                    target.tssc = new TrackSubSubCommand({
+                      args: {
+                        them: them_un
+                      },
+                      opts: _this.argv,
+                      batch: batch,
+                      assertions: assertions
+                    });
+                    (function(__iced_k) {
+                      __iced_deferrals = new iced.Deferrals(__iced_k, {
+                        parent: ___iced_passed_deferral,
+                        filename: "/home/miles/code/vendor/keybase-node-client/src/command/encrypt.iced",
+                        funcname: "Command.run"
+                      });
+                      target.tssc.pre_encrypt(esc(__iced_deferrals.defer({
+                        lineno: 105
+                      })));
+                      __iced_deferrals._fulfill();
+                    })(function() {
+                      return __iced_k(target.user = target.tssc.them);
+                    });
+                  }
+                })(_next);
+              });
+            }
+          };
+          _while(__iced_k);
         });
       })(this)((function(_this) {
         return function() {
           (function(__iced_k) {
-            if (env().is_me(them_un)) {
-              _this.is_self = true;
-              (function(__iced_k) {
-                __iced_deferrals = new iced.Deferrals(__iced_k, {
-                  parent: ___iced_passed_deferral,
-                  filename: "/home/jacko/node-client/src/command/encrypt.iced",
-                  funcname: "Command.run"
-                });
-                User.load_me({
-                  secret: true
-                }, esc(__iced_deferrals.defer({
-                  assign_fn: (function(__slot_1) {
-                    return function() {
-                      return __slot_1.them = arguments[0];
-                    };
-                  })(_this),
-                  lineno: 95
-                })));
-                __iced_deferrals._fulfill();
-              })(__iced_k);
-            } else {
-              _this.is_self = false;
-              _this.tssc = new TrackSubSubCommand({
-                args: {
-                  them: them_un
-                },
-                opts: _this.argv,
-                batch: batch,
-                assertions: assertions
-              });
-              (function(__iced_k) {
-                __iced_deferrals = new iced.Deferrals(__iced_k, {
-                  parent: ___iced_passed_deferral,
-                  filename: "/home/jacko/node-client/src/command/encrypt.iced",
-                  funcname: "Command.run"
-                });
-                _this.tssc.pre_encrypt(esc(__iced_deferrals.defer({
-                  lineno: 99
-                })));
-                __iced_deferrals._fulfill();
-              })(function() {
-                return __iced_k(_this.them = _this.tssc.them);
-              });
-            }
-          })(function() {
-            (function(__iced_k) {
-              __iced_deferrals = new iced.Deferrals(__iced_k, {
-                parent: ___iced_passed_deferral,
-                filename: "/home/jacko/node-client/src/command/encrypt.iced",
-                funcname: "Command.run"
-              });
-              _this.do_encrypt(esc(__iced_deferrals.defer({
-                lineno: 101
-              })));
-              __iced_deferrals._fulfill();
-            })(function() {
-              return cb(null);
+            __iced_deferrals = new iced.Deferrals(__iced_k, {
+              parent: ___iced_passed_deferral,
+              filename: "/home/miles/code/vendor/keybase-node-client/src/command/encrypt.iced",
+              funcname: "Command.run"
             });
+            _this.do_encrypt(esc(__iced_deferrals.defer({
+              lineno: 108
+            })));
+            __iced_deferrals._fulfill();
+          })(function() {
+            return cb(null);
           });
         };
       })(this));


### PR DESCRIPTION
This adds support for multiple recipients. Recipients' usernames can be given as a comma separated list with no spaces. This is backwards compatible (as long as no one has a comma in their username).

Example Usage:
```
    $ keybase encrypt alice,charlie    # encrypts to 2 people, can include yourself.
    $ keybase encrypt --sign alice,bob,charlie    # encrypts to 3 people and signs.
    $ keybase encrypt bob    # still works :)
```

This should address:
https://github.com/keybase/keybase-issues/issues/1405
https://github.com/keybase/keybase-issues/issues/182