### PR TITLE
stop asserting invitation code length

### DIFF
--- a/lib/checkers.js
+++ b/lib/checkers.js
@@ -39,12 +39,6 @@
         return (x.length > 3) && x.match(/^\S+@\S+\.\S+$/);
       }
     },
-    invite_code: {
-      hint: "invite codes are 24 digits long",
-      f: function(x) {
-        return x.length === 24;
-      }
-    },
     email_or_username: {
       hint: "valid usernames are 4-12 letters long"
     },

--- a/lib/command/join.js
+++ b/lib/command/join.js
@@ -87,7 +87,6 @@
         },
         invite: {
           prompt: "Invitation code (leave blank if you don't have one)",
-          checker: checkers.invite_code,
           thrower: function(k, s) {
             if ((s.match(/^\s*$/)) != null) {
               return new E.CleanCancelError(k);
@@ -125,7 +124,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.prompt"
           });
           _this.prompter.run(__iced_deferrals.defer({
@@ -134,7 +133,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 74
+            lineno: 73
           }));
           __iced_deferrals._fulfill();
         });
@@ -159,7 +158,7 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                filename: "/home/jacko/node-client/src/command/join.iced",
                 funcname: "Command.gen_pwh"
               });
               session.gen_pwh({
@@ -173,7 +172,7 @@
                     return __slot_3.pwh_version = arguments[3];
                   };
                 })(_this, _this, _this),
-                lineno: 83
+                lineno: 82
               }));
               __iced_deferrals._fulfill();
             })(function() {
@@ -206,7 +205,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.post"
           });
           req.post({
@@ -219,7 +218,7 @@
                 return body = arguments[1];
               };
             })(),
-            lineno: 98
+            lineno: 97
           }));
           __iced_deferrals._fulfill();
         });
@@ -276,11 +275,11 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.write_out"
           });
           _this.write_config(esc(__iced_deferrals.defer({
-            lineno: 136
+            lineno: 135
           })));
           __iced_deferrals._fulfill();
         });
@@ -289,11 +288,11 @@
           (function(__iced_k) {
             __iced_deferrals = new iced.Deferrals(__iced_k, {
               parent: ___iced_passed_deferral,
-              filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+              filename: "/home/jacko/node-client/src/command/join.iced",
               funcname: "Command.write_out"
             });
             session.write(esc(__iced_deferrals.defer({
-              lineno: 137
+              lineno: 136
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -316,7 +315,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.write_config"
           });
           c.write(__iced_deferrals.defer({
@@ -325,7 +324,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 148
+            lineno: 147
           }));
           __iced_deferrals._fulfill();
         });
@@ -351,7 +350,7 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                filename: "/home/jacko/node-client/src/command/join.iced",
                 funcname: "Command.check_registered"
               });
               prompt_yn(opts, __iced_deferrals.defer({
@@ -361,7 +360,7 @@
                     return rereg = arguments[1];
                   };
                 })(),
-                lineno: 159
+                lineno: 158
               }));
               __iced_deferrals._fulfill();
             })(function() {
@@ -387,11 +386,11 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.request_invite"
           });
           _this.ri_prompt_for_ok(esc(__iced_deferrals.defer({
-            lineno: 168
+            lineno: 167
           })));
           __iced_deferrals._fulfill();
         });
@@ -400,7 +399,7 @@
           (function(__iced_k) {
             __iced_deferrals = new iced.Deferrals(__iced_k, {
               parent: ___iced_passed_deferral,
-              filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+              filename: "/home/jacko/node-client/src/command/join.iced",
               funcname: "Command.request_invite"
             });
             _this.ri_prompt_for_data(esc(__iced_deferrals.defer({
@@ -409,18 +408,18 @@
                   return d2 = arguments[0];
                 };
               })(),
-              lineno: 169
+              lineno: 168
             })));
             __iced_deferrals._fulfill();
           })(function() {
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                filename: "/home/jacko/node-client/src/command/join.iced",
                 funcname: "Command.request_invite"
               });
               _this.ri_post_request(d2, esc(__iced_deferrals.defer({
-                lineno: 170
+                lineno: 169
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -443,7 +442,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.ri_prompt_for_ok"
           });
           prompt_yn(opts, __iced_deferrals.defer({
@@ -453,7 +452,7 @@
                 return go = arguments[1];
               };
             })(),
-            lineno: 179
+            lineno: 178
           }));
           __iced_deferrals._fulfill();
         });
@@ -484,7 +483,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.ri_prompt_for_data"
           });
           prompter.run(__iced_deferrals.defer({
@@ -493,7 +492,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 193
+            lineno: 192
           }));
           __iced_deferrals._fulfill();
         });
@@ -517,7 +516,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.ri_post_request"
           });
           req.post({
@@ -529,7 +528,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 202
+            lineno: 201
           }));
           __iced_deferrals._fulfill();
         });
@@ -551,7 +550,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.run"
           });
           _this.run2(__iced_deferrals.defer({
@@ -560,7 +559,7 @@
                 return err = arguments[0];
               };
             })(),
-            lineno: 210
+            lineno: 209
           }));
           __iced_deferrals._fulfill();
         });
@@ -571,7 +570,7 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                  filename: "/home/jacko/node-client/src/command/join.iced",
                   funcname: "Command.run"
                 });
                 _this.request_invite(__iced_deferrals.defer({
@@ -580,7 +579,7 @@
                       return err = arguments[0];
                     };
                   })(),
-                  lineno: 212
+                  lineno: 211
                 }));
                 __iced_deferrals._fulfill();
               })(__iced_k);
@@ -604,11 +603,11 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+            filename: "/home/jacko/node-client/src/command/join.iced",
             funcname: "Command.run2"
           });
           _this.check_registered(esc(__iced_deferrals.defer({
-            lineno: 220
+            lineno: 219
           })));
           __iced_deferrals._fulfill();
         });
@@ -637,29 +636,29 @@
                 (function(__iced_k) {
                   __iced_deferrals = new iced.Deferrals(__iced_k, {
                     parent: ___iced_passed_deferral,
-                    filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                    filename: "/home/jacko/node-client/src/command/join.iced",
                     funcname: "Command.run2"
                   });
                   _this.prompt(esc(__iced_deferrals.defer({
-                    lineno: 222
+                    lineno: 221
                   })));
                   __iced_deferrals._fulfill();
                 })(function() {
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                      filename: "/home/jacko/node-client/src/command/join.iced",
                       funcname: "Command.run2"
                     });
                     _this.gen_pwh(esc(__iced_deferrals.defer({
-                      lineno: 223
+                      lineno: 222
                     })));
                     __iced_deferrals._fulfill();
                   })(function() {
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                        filename: "/home/jacko/node-client/src/command/join.iced",
                         funcname: "Command.run2"
                       });
                       _this.post(esc(__iced_deferrals.defer({
@@ -668,7 +667,7 @@
                             return retry = arguments[0];
                           };
                         })(),
-                        lineno: 224
+                        lineno: 223
                       })));
                       __iced_deferrals._fulfill();
                     })(_next);
@@ -681,11 +680,11 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/max/src/keybase/node-client/src/command/join.iced",
+                filename: "/home/jacko/node-client/src/command/join.iced",
                 funcname: "Command.run2"
               });
               _this.write_out(esc(__iced_deferrals.defer({
-                lineno: 225
+                lineno: 224
               })));
               __iced_deferrals._fulfill();
             })(function() {

--- a/src/checkers.iced
+++ b/src/checkers.iced
@@ -18,9 +18,6 @@ exports.checkers = checkers =
   email :
     hint : "must be a valid email address"
     f : (x) -> (x.length > 3) and x.match /^\S+@\S+\.\S+$/
-  invite_code :
-    hint : "invite codes are 24 digits long"
-    f : (x) -> x.length is 24
   email_or_username :
     hint : "valid usernames are 4-12 letters long"
   intcheck : (lo, hi, defint) ->

--- a/src/command/join.iced
+++ b/src/command/join.iced
@@ -54,7 +54,6 @@ exports.Command = class Command extends Base
         checker : checkers.email
       invite:
         prompt : "Invitation code (leave blank if you don't have one)"
-        checker : checkers.invite_code
         thrower : (k,s) -> if (s.match /^\s*$/)? then (new E.CleanCancelError(k)) else null
       username :
         prompt : "Your desired username"


### PR DESCRIPTION
Now that we generate bip-0039 codes, their lengths are variable. Also
we've issues temporary promotional invitation codes before (like
"shityeahtwitter" or whatever it was) which probably never worked in the
node client. Rather than checking against a range of lengths that we
might violate in the future, just drop the check here.

Fixes https://github.com/keybase/keybase-issues/issues/1888.